### PR TITLE
Collapsible initiative groups

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,7 @@
 {
   "COMBAT.groupRollsInitiative": "Rolling for Initiative! (grouped)",
   "COMBAT.RollGroupInitiative": "Roll group initiative",
-  "COMBAT.RollGroupInitiativeHint": "Make one roll for an entire group of identical creatures (the same actor) directly from the Combat Tracker \"Roll NPCs\" or \"Roll All\" buttons."
+  "COMBAT.RollGroupInitiativeHint": "Make one roll for an entire group of identical creatures (the same actor) directly from the Combat Tracker \"Roll NPCs\" or \"Roll All\" buttons.",
+  "COMBAT.SkipGrouped": "Skip grouped combatants",
+  "COMBAT.SkipGroupedHint": "Skip combatants except for the first in a group."
 }

--- a/templates/combat-config.html
+++ b/templates/combat-config.html
@@ -13,4 +13,19 @@
   <p class="notes">
     {{localize 'COMBAT.RollGroupInitiativeHint'}}
   </p>
+
+  <label for="skipGrouped">
+    {{localize 'COMBAT.SkipGrouped'}}
+  </label>
+  <input
+    type="checkbox"
+    name="skipGrouped"
+    id="skipGrouped"
+    {{checked
+    skipGrouped}}
+    data-dtype="Boolean"
+  />
+  <p class="notes">
+    {{localize 'COMBAT.SkipGroupedHint'}}
+  </p>
 </div>


### PR DESCRIPTION
This is regarding this conversation: https://discord.com/channels/732325252788387980/732330702754021446/847753625127354388

Here's the final product in action: https://streamable.com/lecxhj

This is pure HTML manipulation so it doesn't actually touch any of your pre-existing logic. It just takes advantage of the fact that group rolling separates combatants into "groups." I wrapped everything in its own hook so you can decided to disable it with a module setting if preferred.